### PR TITLE
Fix broken scp (and possibly others) completions

### DIFF
--- a/fish/aliases.fish
+++ b/fish/aliases.fish
@@ -14,6 +14,13 @@ alias l="ls -alh"
 # and set TERM variable to screen to improve compatibility
 # with remote hosts terminal definitions
 function ssh
+	# Check if current command is ssh, if not bypass this alias.
+	# Needed to not break some commands that use
+	# ssh internally, e.g. scp completions
+	if test "$_" != "ssh"
+		/usr/bin/ssh $argv;
+		return 0;
+	end
 	# for loop to find the first positional argument
 	# which is probably the hostname
 	set flag "";


### PR DESCRIPTION
The ssh alias to set the window title breaks scp completions
(and possibly others): they use the ssh command internally
(e.g. to retrieve the list of remote paths), and our
customisations breaks them.
Solve by checking the executed command, which should be 'ssh'
only in case of direct ssh command launched in the shell,
and bypass the alias if different command.